### PR TITLE
Update setStrokeWidth

### DIFF
--- a/android/src/ti/modules/titanium/paint/UIPaintView.java
+++ b/android/src/ti/modules/titanium/paint/UIPaintView.java
@@ -59,7 +59,7 @@ public class UIPaintView extends TiUIView {
 	public void setStrokeWidth(Float width) {
 		Log.d(LCAT, "Changing stroke width.");
 		tiPaintView.finalizePaths();
-		tiPaint.setStrokeWidth(width);
+		tiPaint.setStrokeWidth(TiConvert.toFloat(width));
 		tiPaint.setAlpha(alphaState);
 	}
 


### PR DESCRIPTION
Fixing bug (In android 5.0 or higher, you can't change stroke width after initializing view).