### PR TITLE
[MOD-2372] Recompile ti.paint for SDK 7.0.0 compatability

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -21,7 +21,7 @@ project(TiPaint)
 
 set(TiPaint_VERSION 0.1.0)
 
-set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/6.2.0.GA/windows")
+set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/7.0.0.GA/windows")
 
 SET(CMAKE_FIND_LIBRARY_PREFIXES "")
 SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
@@ -40,6 +40,7 @@ find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
 find_package(LayoutEngine REQUIRED)
 find_package(TitaniumWindows_UI REQUIRED)
+find_package(JavaScriptCore REQUIRED)
 
 enable_testing()
 
@@ -72,6 +73,7 @@ target_include_directories(TiPaint PUBLIC
   )
 
 target_link_libraries(TiPaint
+  JavaScriptCore
   HAL
   TitaniumKit
   LayoutEngine

--- a/windows/cmake/FindJavascriptCore.cmake
+++ b/windows/cmake/FindJavascriptCore.cmake
@@ -1,61 +1,40 @@
-# HAL
+# FindJavaScriptCore
+# Author: Chris Williams
 #
-# Copyright (c) 2017 Axway All Rights Reserved.
+# Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
 # Licensed under the terms of the Apache Public License.
 # Please see the LICENSE included with this distribution for details.
 
-# Author: Matt Langston
-# Created: 2014.09.03
-#
-# Try to find JavaScriptCore. Once done this will define:
-#
-#  JavaScriptCore_FOUND       - system has JavaScriptCore
-#  JavaScriptCore_INCLUDE_DIRS - the include directory
-#  JavaScriptCore_LIBRARY_DIR - the directory containing the library
-#  JavaScriptCore_LIBRARIES   - link these to use JavaScriptCore
+# Author: Chris Williams
+# Created: 2014.12.02
 
-find_package(PkgConfig)
-
-pkg_check_modules(PC_JavaScriptCore QUIET JavaScriptCore)
-
-find_path(JavaScriptCore_INCLUDE_DIRS
-  NAMES JavaScriptCore/JavaScript.h
-  HINTS ${PC_JavaScriptCore_INCLUDE_DIRS} ${PC_JavaScriptCore_INCLUDEDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES includes
-  )
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+  set(PLATFORM phone)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+  set(PLATFORM store)
+else()
+  message(FATAL_ERROR "This app supports Store / Phone only.")
+endif()
 
 set(JavaScriptCore_ARCH "x86")
 if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
   set(JavaScriptCore_ARCH "arm")
 endif()
 
-find_library(JavaScriptCore_LIBRARIES
-  NAMES JavaScriptCore JavaScriptCore-Debug JavaScriptCore-Release
-  HINTS ${PC_JavaScriptCore_LIBRARY_DIRS} ${PC_JavaScriptCore_LIBDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES ${JavaScriptCore_ARCH}
+# Taken and slightly modified from build's JavaScriptCore_Targets.cmake file
+# INTERFACE_INCLUDE_DIRECTORIES is modified to point to our pre-packaged include dir for module
+
+# Create imported target JavaScriptCore
+add_library(JavaScriptCore SHARED IMPORTED)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  COMPATIBLE_INTERFACE_STRING "JavaScriptCore_MAJOR_VERSION"
+  INTERFACE_JavaScriptCore_MAJOR_VERSION "0"
+)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  IMPORTED_IMPLIB "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.lib"
+  IMPORTED_LOCATION "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.dll"
   )
-
-if(NOT JavaScriptCore_LIBRARIES MATCHES ".+-NOTFOUND")
-  get_filename_component(JavaScriptCore_LIBRARY_DIR ${JavaScriptCore_LIBRARIES} DIRECTORY)
-
-  # If we found the JavaScriptCore library and we're using a Visual
-  # Studio generator and we're targeting either WindowsStore or
-  # WindowsPhone, then allow Visual Studio to use both the
-  # JavaScriptCore-Debug.lib and JavaScriptCore-Release.lib if they
-  # exist.
-  if(CMAKE_GENERATOR MATCHES "^Visual Studio .+" AND CMAKE_SYSTEM_NAME MATCHES "^Windows(Store|Phone)")
-    string(REGEX REPLACE "-(Debug|Release)" "-$(Configuration)" JavaScriptCore_LIBRARIES ${JavaScriptCore_LIBRARIES})
-  endif()
-
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JavaScriptCore DEFAULT_MSG JavaScriptCore_INCLUDE_DIRS JavaScriptCore_LIBRARIES)
-
-# message(STATUS "MDL: CMAKE_CONFIGURATION_TYPES   = ${CMAKE_CONFIGURATION_TYPES}")
-# message(STATUS "MDL: JAVASCRIPTCORE_FOUND        = ${JAVASCRIPTCORE_FOUND}")
-# message(STATUS "MDL: JavaScriptCore_INCLUDE_DIRS = ${JavaScriptCore_INCLUDE_DIRS}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARY_DIR  = ${JavaScriptCore_LIBRARY_DIR}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARIES    = ${JavaScriptCore_LIBRARIES}")

--- a/windows/cmake/FindJavascriptCore.cmake
+++ b/windows/cmake/FindJavascriptCore.cmake
@@ -1,7 +1,7 @@
 # FindJavaScriptCore
 # Author: Chris Williams
 #
-# Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+# Copyright (c) 2017 by Axway All Rights Reserved.
 # Licensed under the terms of the Apache Public License.
 # Please see the LICENSE included with this distribution for details.
 

--- a/windows/manifest
+++ b/windows/manifest
@@ -1,4 +1,4 @@
-version: 2.1.0
+version: 3.0.0
 apiversion: 4
 architectures: ARM x86
 description: Provides a paint surface user interface view.

--- a/windows/manifest
+++ b/windows/manifest
@@ -1,5 +1,5 @@
-version: 2.0.0
-apiversion: 3
+version: 2.1.0
+apiversion: 4
 architectures: ARM x86
 description: Provides a paint surface user interface view.
 author: Gary Mathews
@@ -12,4 +12,4 @@ moduleid: ti.paint
 moduleIdAsIdentifier: TiPaint
 guid: 3a8ff336-741e-4a70-bb0c-01a4e44574e9
 platform: windows
-minsdk: 6.1.1
+minsdk: 7.0.0


### PR DESCRIPTION
JIRA ticket: [MOD-2372](https://jira.appcelerator.org/browse/MOD-2372)

Upcoming Titanium SDK 7.0.0 we are expecting module apiversion update. We need to bump up the version. SDK 7.0.0 will also include JavaScriptCore update, so we need to update cmake project too.
