### PR TITLE
Add Titanium SDK 7.3.0 compatibility

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -21,7 +21,7 @@ project(TiPaint)
 
 set(TiPaint_VERSION 0.1.0)
 
-set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/7.1.1.GA/windows")
+set(WINDOWS_SOURCE_DIR "C:/ProgramData/Titanium/mobilesdk/win32/7.3.0.GA/windows")
 
 SET(CMAKE_FIND_LIBRARY_PREFIXES "")
 SET(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")

--- a/windows/manifest
+++ b/windows/manifest
@@ -1,5 +1,5 @@
-version: 3.1.0
-apiversion: 5
+version: 3.2.0
+apiversion: 6
 architectures: ARM x86
 description: Provides a paint surface user interface view.
 author: Gary Mathews
@@ -12,4 +12,4 @@ moduleid: ti.paint
 moduleIdAsIdentifier: TiPaint
 guid: 3a8ff336-741e-4a70-bb0c-01a4e44574e9
 platform: windows
-minsdk: 7.1.1
+minsdk: 7.3.0


### PR DESCRIPTION
- Bump to apiversion 6
- Titanium SDK 7.3.0 compatibility for Windows